### PR TITLE
Report stderr when untarring artifacts.

### DIFF
--- a/harpoon-agent/container.go
+++ b/harpoon-agent/container.go
@@ -536,12 +536,10 @@ const (
 	containerStop                    = "stop"
 )
 
-type logWriter struct {
-	fmt string
-}
+type logWriter string
 
 func (w logWriter) Write(s []byte) (int, error) {
-	log.Printf(w.fmt, string(s))
+	log.Printf(string(w), string(s))
 	return len(s), nil
 }
 
@@ -554,8 +552,8 @@ func extractArtifact(src io.Reader, dst string, compression string) (err error) 
 
 	// An ID to associate stderr messages with a process. A number between [1,999] should
 	// be enough to prevent a collision while small enough to be easily readable.
-	logId := strconv.Itoa(rand.Intn(999) + 1)
-	log.Printf("extracting with cmd[%s]: tar -xv%s -C %s ", logId, compression, dst)
+	logID := strconv.Itoa(rand.Intn(999) + 1)
+	log.Printf("extracting with cmd[%s]: tar -xv%s -C %s ", logID, compression, dst)
 	cmd := exec.Command("tar", "-xv"+compression, "-C", dst)
 	cmd.Stdin = src
 	// It's incredibly hard to debug failures in tar unless stderr is available.
@@ -563,7 +561,7 @@ func extractArtifact(src io.Reader, dst string, compression string) (err error) 
 	// Sadly tar has error conditions in which it reports success even though it fails.
 	// (Seen when missing the FOWNER capability.)  Therefore we can't depend upon the
 	// error code to determine when to report stderr.
-	cmd.Stderr = logWriter{"tar[" + logId + "]> %s"}
+	cmd.Stderr = logWriter("tar[" + logID + "]> %s")
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("tar extraction failed: %s", err)

--- a/harpoon-agent/container.go
+++ b/harpoon-agent/container.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -542,13 +544,32 @@ func extractArtifact(src io.Reader, dst string, compression string) (err error) 
 		}
 	}()
 
-	cmd := exec.Command("tar", "-C", dst, "-x"+compression)
+	log.Printf("extracting with cmd: tar -xv%s -C %s ", compression, dst)
+	cmd := exec.Command("tar", "-xv"+compression, "-C", dst)
 	cmd.Stdin = src
 
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("tar extraction failed: %s", err)
+	// It's incredibly hard to debug failures in tar unless stderr is available.
+	// Fortunately tar only spews to stderr when something goes wrong.
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return errors.New("could not open tar's stderr")
 	}
 
+	if err := cmd.Start(); err != nil {
+		log.Printf("could not start tar command: %s", err)
+	}
+
+	tarout, err := ioutil.ReadAll(stderr)
+	if err != nil {
+		log.Printf("error while from tar's stderr: %s", err)
+	}
+	if len(tarout) != 0 {
+		log.Printf("stderr from tar: %s", string(tarout))
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("tar extraction failed: %s", err)
+	}
 	return nil
 }
 

--- a/harpoon-agent/container.go
+++ b/harpoon-agent/container.go
@@ -552,8 +552,9 @@ func extractArtifact(src io.Reader, dst string, compression string) (err error) 
 		}
 	}()
 
-	// Include an ID to associate stderr messages with a process
-	logId := strconv.Itoa(rand.Intn(998) + 1)
+	// An ID to associate stderr messages with a process. A number between [1,999] should
+	// be enough to prevent a collision while small enough to be easily readable.
+	logId := strconv.Itoa(rand.Intn(999) + 1)
 	log.Printf("extracting with cmd[%s]: tar -xv%s -C %s ", logId, compression, dst)
 	cmd := exec.Command("tar", "-xv"+compression, "-C", dst)
 	cmd.Stdin = src


### PR DESCRIPTION
When tar fails it is incredibly hard to debug failures unless you have what it spewed to stderr.  Fortunately
it only spews to stderr when something goes wrong, so reporting stderr usually results in no messages.