### PR TITLE
Refactor integration test logic.

### DIFF
--- a/_integration/agent-test-basic/basic_test.go
+++ b/_integration/agent-test-basic/basic_test.go
@@ -1,163 +1,21 @@
 package agent_test
 
 import (
-	"encoding/json"
-	"flag"
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/soundcloud/harpoon/harpoon-agent/lib"
 )
 
-var (
-	agentURL   = flag.String("integ.agent.url", "", "integration test URL")
-	warheadURL = flag.String("integ.warhead.url", "", "integration test container URL")
-)
-
-func watchEvents(agentURL string, id string) func() {
-	c, err := agent.NewClient(agentURL)
-	if err != nil {
-		panic("can't connect to agent to watch events")
-	}
-
-	events, stopper, err := c.Events()
-	if err != nil {
-		panic("can't watch events")
-	}
-
-	stopc := make(chan struct{})
-
-	go func() {
-		for {
-			select {
-			case event := <-events:
-				_, ok := event.Containers[id]
-				if !ok {
-					continue
-				}
-				p, err := json.MarshalIndent(event, "", "    ")
-				if err == nil {
-					fmt.Printf("EVENT: %s\n", string(p))
-				} else {
-					fmt.Printf("EVENT: %#v\n", event)
-				}
-
-			case <-stopc:
-				stopper.Stop()
-				return
-			}
-		}
-	}()
-
-	return func() {
-		stopc <- struct{}{}
-	}
-}
-
-func watchLogs(agentURL string, id string) func() {
-	c, err := agent.NewClient(agentURL)
-	if err != nil {
-		panic("can't connect to agent to watch events")
-	}
-
-	logs, _, err := c.Log(id, 10)
-	if err != nil {
-		panic("can't watch logs")
-	}
-
-	stopc := make(chan struct{})
-
-	go func() {
-		for {
-			select {
-			case line := <-logs:
-				if line == "" {
-					continue
-				}
-				fmt.Printf("LOG: %s", line)
-			case <-stopc:
-				return
-			}
-		}
-	}()
-
-	return func() {
-		stopc <- struct{}{}
-	}
-}
-
 func TestAgent(t *testing.T) {
-	var (
-		config = agent.ContainerConfig{
-			ArtifactURL: *warheadURL,
-			Command: agent.Command{
-				WorkingDir: "/",
-				Exec:       []string{"bin/warhead", "-listen", "0.0.0.0:$PORT_HTTP", "-log-interval", "0.1s"},
-			},
-			Resources: agent.Resources{
-				Mem: 32,
-				CPU: 1,
-			},
-			Ports: map[string]uint16{
-				"HTTP": 0,
-			},
-			Restart: "no",
-		}
-	)
+	cf := newContainerFixture(t, "basic-test")
 
-	cid := "basic-test"
-	client, err := agent.NewClient(*agentURL)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Create container
-	statuses := map[agent.ContainerStatus]struct{}{
-		agent.ContainerStatusCreated: struct{}{},
-	}
-	wc := client.Wait(cid, statuses, 20*time.Second)
-	if err := client.Create(cid, config); err != nil {
-		t.Fatal(err)
-	}
-	w := <-wc
-	if w.Err != nil {
-		t.Fatal(w.Err)
-	}
-
-	// Start container.  When successful the container will transition from created->running.
-	statuses = map[agent.ContainerStatus]struct{}{
-		agent.ContainerStatusRunning: struct{}{},
-	}
-	wc = client.Wait(cid, statuses, 2*time.Second)
-	if err := client.Start(cid); err != nil {
-		t.Fatal(err)
-	}
-	w = <-wc
-	if w.Err != nil {
-		t.Fatalf("Never reached running state: %s", w.Err)
-	}
-
-	// Stop container.  When successful the container will transition from created->running.
-	statuses = map[agent.ContainerStatus]struct{}{
-		agent.ContainerStatusFinished: struct{}{},
-	}
-	wc = client.Wait(cid, statuses, 10*time.Second)
-	if err := client.Stop(cid); err != nil {
-		t.Fatal(err)
-	}
-	w = <-wc
-	if w.Err != nil {
-		t.Fatalf("Never reached finished state: %s", w.Err)
-	}
-
-	// Destroy container
-	if err := client.Destroy("basic-test"); err != nil {
-		t.Fatal(err)
-	}
+	cf.create(agent.ContainerStatusCreated)
+	cf.start(agent.ContainerStatusRunning)
+	cf.stop(agent.ContainerStatusFinished)
+	cf.destroy()
 
 	// Verify that it's gone.
-	if _, err := client.Get("basic-test"); err != agent.ErrContainerNotExist {
+	if _, err := cf.client.Get(cf.id); err != agent.ErrContainerNotExist {
 		t.Fatal(err)
 	}
 }

--- a/_integration/agent-test-basic/failed_creation_test.go
+++ b/_integration/agent-test-basic/failed_creation_test.go
@@ -1,54 +1,15 @@
 package agent_test
 
 import (
-	"flag"
-	"log"
 	"testing"
-	"time"
 
 	"github.com/soundcloud/harpoon/harpoon-agent/lib"
 )
 
-var (
-	agentURL = flag.String("integ.agent.url", "", "integration test URL")
-)
-
 func TestAgent(t *testing.T) {
-	var (
-		config = agent.ContainerConfig{
-			ArtifactURL: "http://asset-host.test/completely_bogus.tgz",
-			Command: agent.Command{
-				WorkingDir: "/",
-				Exec:       []string{"bin/warhead", "-port", "$HTTP_PORT"},
-			},
-			Resources: agent.Resources{
-				Mem: 32,
-				CPU: 1,
-			},
-			Restart: "no",
-		}
-	)
-
-	id := "stillborn-instance"
-	client, err := agent.NewClient(*agentURL)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	wanted := map[agent.ContainerStatus]struct{}{
-		agent.ContainerStatusDeleted: struct{}{},
-		agent.ContainerStatusCreated: struct{}{},
-	}
-	wc := client.Wait(id, wanted, 30*time.Second)
-
-	if err := client.Create(id, config); err != nil {
-		t.Fatalf("Initial creation failed: %s", err)
-	}
-
-	w := <-wc
-
-	if w.Err != nil {
-		log.Fatalf("Wait results failed: %s", w.Err)
-	}
-
+	cf := newContainerFixture(t, "stillborn-instance")
+	// Useless URL which will never load
+	cf.config.ArtifactURL = "http://asset-host.testisquat/completely_bogus.tgz"
+	// Creation should fail with status deleted
+	cf.create(agent.ContainerStatusDeleted)
 }

--- a/_integration/agent-test-basic/integ_test.go
+++ b/_integration/agent-test-basic/integ_test.go
@@ -1,0 +1,178 @@
+package agent_test
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/soundcloud/harpoon/harpoon-agent/lib"
+)
+
+var (
+	agentURL   = flag.String("integ.agent.url", "", "integration test URL")
+	warheadURL = flag.String("integ.warhead.url", "", "integration test container URL")
+)
+
+type containerFixture struct {
+	t      *testing.T
+	id     string
+	config agent.ContainerConfig
+	client agent.Agent
+}
+
+func newContainerFixture(t *testing.T, id string) *containerFixture {
+	cf := &containerFixture{
+		t:  t,
+		id: id,
+	}
+	cf.config = agent.ContainerConfig{
+		ArtifactURL: *warheadURL,
+		Command: agent.Command{
+			WorkingDir: "/",
+			Exec:       []string{"bin/warhead", "-listen", "0.0.0.0:$PORT_HTTP", "-log-interval", "0.1s"},
+		},
+		Resources: agent.Resources{
+			Mem: 32,
+			CPU: 1,
+		},
+		Ports: map[string]uint16{
+			"HTTP": 0,
+		},
+		Restart: "no",
+	}
+
+	client, err := agent.NewClient(*agentURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cf.client = client
+	return cf
+}
+
+func (cf *containerFixture) create(statuses ...agent.ContainerStatus) {
+	statusSet := map[agent.ContainerStatus]struct{}{}
+	for _, s := range statuses {
+		statusSet[s] = struct{}{}
+	}
+
+	wc := cf.client.Wait(cf.id, statusSet, 20*time.Second)
+	if err := cf.client.Create(cf.id, cf.config); err != nil {
+		cf.t.Fatal(err)
+	}
+	w := <-wc
+	if w.Err != nil {
+		cf.t.Fatalf("Create failed: %s", w.Err)
+	}
+}
+
+func (cf *containerFixture) start(statuses ...agent.ContainerStatus) {
+	statusSet := map[agent.ContainerStatus]struct{}{}
+	for _, s := range statuses {
+		statusSet[s] = struct{}{}
+	}
+
+	wc := cf.client.Wait(cf.id, statusSet, 2*time.Second)
+	if err := cf.client.Start(cf.id); err != nil {
+		cf.t.Fatal(err)
+	}
+	w := <-wc
+	if w.Err != nil {
+		cf.t.Fatalf("Start failed: %s", w.Err)
+	}
+}
+
+func (cf *containerFixture) stop(statuses ...agent.ContainerStatus) {
+	statusSet := map[agent.ContainerStatus]struct{}{}
+	for _, s := range statuses {
+		statusSet[s] = struct{}{}
+	}
+
+	wc := cf.client.Wait(cf.id, statusSet, 2*time.Second)
+	if err := cf.client.Stop(cf.id); err != nil {
+		cf.t.Fatal(err)
+	}
+	w := <-wc
+	if w.Err != nil {
+		cf.t.Fatalf("Stop failed: %s", w.Err)
+	}
+}
+
+func (cf *containerFixture) destroy() {
+	if err := cf.client.Destroy(cf.id); err != nil {
+		cf.t.Fatal(err)
+	}
+}
+
+func (cf *containerFixture) watchEvents() func() {
+	c, err := agent.NewClient(*agentURL)
+	if err != nil {
+		panic("can't connect to agent to watch events")
+	}
+
+	events, stopper, err := c.Events()
+	if err != nil {
+		panic("can't watch events")
+	}
+
+	stopc := make(chan struct{})
+
+	go func() {
+		for {
+			select {
+			case event := <-events:
+				_, ok := event.Containers[cf.id]
+				if !ok {
+					continue
+				}
+				p, err := json.MarshalIndent(event, "", "    ")
+				if err == nil {
+					fmt.Printf("EVENT: %s\n", string(p))
+				} else {
+					fmt.Printf("EVENT: %#v\n", event)
+				}
+
+			case <-stopc:
+				stopper.Stop()
+				return
+			}
+		}
+	}()
+
+	return func() {
+		stopc <- struct{}{}
+	}
+}
+
+func (cf *containerFixture) watchLogs() func() {
+	c, err := agent.NewClient(*agentURL)
+	if err != nil {
+		panic("can't connect to agent to watch events")
+	}
+
+	logs, _, err := c.Log(cf.id, 10)
+	if err != nil {
+		panic("can't watch logs")
+	}
+
+	stopc := make(chan struct{})
+
+	go func() {
+		for {
+			select {
+			case line := <-logs:
+				if line == "" {
+					continue
+				}
+				fmt.Printf("LOG: %s", line)
+			case <-stopc:
+				return
+			}
+		}
+	}()
+
+	return func() {
+		stopc <- struct{}{}
+	}
+}

--- a/_integration/run.sh
+++ b/_integration/run.sh
@@ -116,11 +116,16 @@ fi
 echo "run: waiting for agent to start"
 ./retry 5 1 curl -s ${AGENT_URL}/api/v0/containers || abort "could not start agent"
 
+function integ_test_agent {
+  go test -v $1 agent-test-basic/integ_test.go -integ.agent.url=${AGENT_URL} -integ.warhead.url=${WARHEAD_URL}
+}
+
 echo "==== Agent: Basic Tests ===="
-go test -v agent-test-basic/basic_test.go -integ.agent.url=${AGENT_URL} -integ.warhead.url=${WARHEAD_URL}
+integ_test_agent agent-test-basic/basic_test.go
 
 echo "==== Agent: Failed Creation Tests ===="
-go test -v agent-test-basic/failed_creation_test.go -integ.agent.url=${AGENT_URL}
+integ_test_agent agent-test-basic/failed_creation_test.go
+
 
 echo "agent logfile: $logfile"
 


### PR DESCRIPTION
All integration tests I've contemplated have the same sets of operations.  I've pulled these out, so we can now write additional tests simply while only focusing on the important details in the test structure.