### PR TITLE
Remove tramp data for create

### DIFF
--- a/harpoon-agent/api_test.go
+++ b/harpoon-agent/api_test.go
@@ -81,6 +81,8 @@ func TestContainerList(t *testing.T) {
 		},
 		false,
 		nil,
+		func() {},
+		0,
 	)
 
 	registry.register(cont)
@@ -249,7 +251,7 @@ func TestLogAPICanTailLogs(t *testing.T) {
 
 	createReceiveLogsFixture(t, registry)
 
-	c := newFakeContainer("123", "", volumes{}, agent.ContainerConfig{}, false, nil)
+	c := newFakeContainer("123", "", volumes{}, agent.ContainerConfig{}, false, nil, func() {}, 0)
 	registry.register(c)
 
 	// UDP has some weirdness with processing, so we use the container log's subscription
@@ -336,7 +338,7 @@ func TestLogAPILogTailIncludesHistory(t *testing.T) {
 
 	createReceiveLogsFixture(t, registry)
 
-	c := newFakeContainer("123", "", volumes{}, agent.ContainerConfig{}, false, nil)
+	c := newFakeContainer("123", "", volumes{}, agent.ContainerConfig{}, false, nil, func() {}, 0)
 	registry.register(c)
 
 	// UDP has some weirdness with processing, so we use the container log's subscription
@@ -425,7 +427,7 @@ func TestLogAPICanRetrieveLastLines(t *testing.T) {
 
 	createReceiveLogsFixture(t, registry)
 
-	c := newFakeContainer("123", "", volumes{}, agent.ContainerConfig{}, false, nil)
+	c := newFakeContainer("123", "", volumes{}, agent.ContainerConfig{}, false, nil, func() {}, 0)
 	registry.register(c)
 
 	// UDP has some weirdness with processing, so we use the container log's subscription

--- a/harpoon-agent/container.go
+++ b/harpoon-agent/container.go
@@ -286,7 +286,6 @@ func (c *realContainer) create() error {
 	defer func() {
 		if !success {
 			c.destroy()
-			c.unregister()
 		}
 	}()
 
@@ -346,7 +345,6 @@ func (c *realContainer) secondPhaseCreate() {
 	defer func() {
 		if !success {
 			c.destroy()
-			c.unregister()
 		}
 	}()
 

--- a/harpoon-agent/fake_container.go
+++ b/harpoon-agent/fake_container.go
@@ -31,6 +31,8 @@ func newFakeContainer(
 	config agent.ContainerConfig,
 	_ bool,
 	_ *portDB,
+	_ func(),
+	_ time.Duration,
 ) container {
 	c := &fakeContainer{
 		ContainerInstance: agent.ContainerInstance{
@@ -54,11 +56,9 @@ func newFakeContainer(
 	return c
 }
 
-func (c *fakeContainer) Create(unregister func(), downloadTimeout time.Duration) error {
+func (c *fakeContainer) Create() error {
 	req := createRequest{
-		unregister:      unregister,
-		downloadTimeout: downloadTimeout,
-		resp:            make(chan error),
+		resp: make(chan error),
 	}
 	c.createc <- req
 	return <-req.resp

--- a/harpoon-agent/instrumentation_test.go
+++ b/harpoon-agent/instrumentation_test.go
@@ -16,7 +16,7 @@ import (
 func TestReceiveLogInstrumentation(t *testing.T) {
 	registry := newRegistry(nopServiceDiscovery{})
 	createReceiveLogsFixture(t, registry)
-	c := newFakeContainer("123", "", volumes{}, agent.ContainerConfig{}, false, nil)
+	c := newFakeContainer("123", "", volumes{}, agent.ContainerConfig{}, false, nil, func() {}, 0)
 	registry.register(c)
 	linec := make(chan string, 10) // Plenty of room before anything gets dropped
 	c.Logs().notify(linec)
@@ -47,11 +47,11 @@ func TestLogInstrumentationNotifyWithoutWatchers(t *testing.T) {
 	registry := newRegistry(nopServiceDiscovery{})
 	createReceiveLogsFixture(t, registry)
 
-	registry.register(newFakeContainer("123", "", volumes{}, agent.ContainerConfig{}, false, nil))
+	registry.register(newFakeContainer("123", "", volumes{}, agent.ContainerConfig{}, false, nil, func() {}, 0))
 
 	// Create a second container which shouldn't receive any notifications
 	// for the first channel.  This channel
-	nonDestinationContainer := newFakeContainer("456", "", volumes{}, agent.ContainerConfig{}, false, nil)
+	nonDestinationContainer := newFakeContainer("456", "", volumes{}, agent.ContainerConfig{}, false, nil, func() {}, 0)
 	registry.register(nonDestinationContainer)
 	nonDestinationLinec := make(chan string, 1)
 	nonDestinationContainer.Logs().notify(nonDestinationLinec)
@@ -70,7 +70,7 @@ func TestLogInstrumentationNotifyWatchers(t *testing.T) {
 	registry := newRegistry(nopServiceDiscovery{})
 	createReceiveLogsFixture(t, registry)
 
-	c := newFakeContainer("123", "", volumes{}, agent.ContainerConfig{}, false, nil)
+	c := newFakeContainer("123", "", volumes{}, agent.ContainerConfig{}, false, nil, func() {}, 0)
 	registry.register(c)
 	linec1 := make(chan string, 1)
 	linec2 := make(chan string, 1)
@@ -92,7 +92,7 @@ func TestLogInstrumentationNotifyWithBlockedWatcher(t *testing.T) {
 	registry := newRegistry(nopServiceDiscovery{})
 	createReceiveLogsFixture(t, registry)
 
-	c := newFakeContainer("123", "", volumes{}, agent.ContainerConfig{}, false, nil)
+	c := newFakeContainer("123", "", volumes{}, agent.ContainerConfig{}, false, nil, func() {}, 0)
 	registry.register(c)
 	linec1 := make(chan string, 1)
 	linec2 := make(chan string) // Blocked channel

--- a/harpoon-agent/recovery.go
+++ b/harpoon-agent/recovery.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/soundcloud/harpoon/harpoon-agent/lib"
 )
@@ -54,7 +55,9 @@ func recoverContainer(id string, containerRoot string, r *registry, pdb *portDB,
 		return fmt.Errorf("could not parse agent file: %s", err)
 	}
 
-	c := newContainer(id, containerRoot, vols, agentConfig, debug, pdb)
+	// Because the container already exists the download argument will never be used, and
+	// therefore its value is completely arbitrary.
+	c := newContainer(id, containerRoot, vols, agentConfig, debug, pdb, func() { r.remove(id) }, 42*time.Second)
 	if err := c.Recover(); err != nil {
 		c.Exit()
 		return err

--- a/harpoon-agent/registry_test.go
+++ b/harpoon-agent/registry_test.go
@@ -16,7 +16,7 @@ func TestMessagesGetWrittenToLogs(t *testing.T) {
 
 	createReceiveLogsFixture(t, registry)
 
-	c := newFakeContainer("123", "", volumes{}, agent.ContainerConfig{}, false, nil)
+	c := newFakeContainer("123", "", volumes{}, agent.ContainerConfig{}, false, nil, func() {}, 0)
 	registry.register(c)
 
 	// UDP has some weirdness with processing, so we use the container log's subscription
@@ -42,7 +42,7 @@ func TestLogRoutingOfDefectiveMessages(t *testing.T) {
 
 	createReceiveLogsFixture(t, registry)
 
-	c := newFakeContainer("123", "", volumes{}, agent.ContainerConfig{}, false, nil)
+	c := newFakeContainer("123", "", volumes{}, agent.ContainerConfig{}, false, nil, func() {}, 0)
 	registry.register(c)
 
 	linec := make(chan string, 10) // Plenty of room before anything gets dropped
@@ -58,7 +58,7 @@ func TestLogRoutingOfDefectiveMessages(t *testing.T) {
 
 func TestNonBlockingLoop(t *testing.T) {
 	r := newRegistry(nopServiceDiscovery{})
-	c := newFakeContainer("123", "", volumes{}, agent.ContainerConfig{}, false, nil)
+	c := newFakeContainer("123", "", volumes{}, agent.ContainerConfig{}, false, nil, func() {}, 0)
 	r.register(c)
 	statec := make(chan agent.ContainerInstance)
 	statec2 := make(chan agent.ContainerInstance)


### PR DESCRIPTION
[This is a component of a much larger set of changes.]

The create operation is different from all others in that it passes information into the container's loop() function.  This causes many ugly complications when implementing loop() as a state machine controller.  By moving the values into the container struct itself, the state machine implementation becomes significantly cleaner.
